### PR TITLE
fix: fix data-resourceroot parsing

### DIFF
--- a/js/ui5-fontawesome.js
+++ b/js/ui5-fontawesome.js
@@ -8,7 +8,7 @@ sap.ui.require([
 		var scriptTag = document.querySelector('SCRIPT[src][id=ui5-fontawesome]')
 		var scriptConfig = scriptTag.getAttribute('data-resourceroot')
 		if (scriptConfig) {
-			return scriptConfig.slice(-1) == '/' ? scriptTag : scriptTag + '/'
+			return scriptConfig.slice(-1) == '/' ? scriptConfig : scriptConfig + '/'
 		}
 		var scriptSrc = scriptTag.getAttribute('src')
 		var regexTest = /^((?:.*\/)?ui5-fontawesome\/)/


### PR DESCRIPTION
scriptConfig is the actual value of `data-resourceroot`, and it should be returned when calling `getResourceRoot()`, with slash '/' appended if omitted.
I'm not sure why `scriptTag` was used, which is a DOM Element. Probably a mistake.

Closes #16.